### PR TITLE
Support IMGPROXY_SKIP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,11 @@ In ``settings.py``:
        (1024, 768),
    )
 
+   # In case you want to skip imgproxy url generation, set this flag to True.
+   # When generation is being skipped, all the resolutions return the url of
+   # the source file if possible or None.
+   IMGPROXY_SKIP = False
+
 In ``serializers.py``:
 
 .. code:: python

--- a/drf_imgproxy/serializers.py
+++ b/drf_imgproxy/serializers.py
@@ -37,8 +37,16 @@ class ImgproxyResizeableImageField(serializers.ImageField):
 
         return urljoin(settings.IMGPROXY_HOST, signed_url)
 
+    def generate_proxy_skipped_url(self, width, height, data):
+        return getattr(data, 'url', None)
+
     def to_representation(self, data):
         if not data.name:
             return None
-        return {f'{h}p': self.generate_signed_url(w, h, data)
+
+        url_generator = self.generate_signed_url
+        if getattr(settings, 'IMGPROXY_SKIP', False):
+            url_generator = self.generate_proxy_skipped_url
+
+        return {f'{h}p': url_generator(w, h, data)
                 for w, h in settings.IMGPROXY_RESOLUTIONS}

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,11 +1,13 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
 from drf_imgproxy.serializers import ImgproxyResizeableImageField
 
 
 class FakeFile:
-    def __init__(self, name):
+    def __init__(self, name, url=None):
         self.name = name
+        self.url = url
 
 
 class ImgproxyResizeableImageFieldTest(TestCase):
@@ -29,3 +31,15 @@ class ImgproxyResizeableImageFieldTest(TestCase):
     def test_invalid_file_to_representation(self):
         res = self.serializer.to_representation(FakeFile(None))
         self.assertEqual(res, None)
+
+    def test_skip(self):
+        fake_url = 'https://imgproxy.test.local/test.png'
+        file = FakeFile('test.png', url=fake_url)
+
+        with self.settings(IMGPROXY_SKIP=True):
+            res = self.serializer.to_representation(file)
+
+            self.assertEqual(res, {
+                '480p': fake_url,
+                '600p': fake_url,
+            })


### PR DESCRIPTION
My use case was to be able to skip running the url generation when the server is being run in an local environment.